### PR TITLE
Force Node 10 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:10
 
 WORKDIR /app/website
 


### PR DESCRIPTION
There's build issues in Node 12+:
```
Error: Cannot find module '@babel/compat-data/corejs3-shipped-proposals'
```

Here's one of many examples of a similar issue if the
above error is googled:
https://github.com/JeffreyWay/laravel-mix/issues/2383

To avoid this issue on Netlify I also set env variable
`NODE_VERSION=10` on the build settings page.